### PR TITLE
docs: moved install firefox to setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,7 @@
   - [1.2. Design](#12-design)
 - [2. Machine Setup.](#2-machine-setup)
   - [2.1. Developer Setup and Documentation.](#21-developer-setup-and-documentation)
-  - [2.2. Testing Setup and Documentation.](#22-testing-setup-and-documentation)
-  - [2.3. Infrastructure Setup and Documentation.](#23-infrastructure-setup-and-documentation)
+  - [2.2. Infrastructure Setup and Documentation.](#22-infrastructure-setup-and-documentation)
 
 ## 1. Getting Oriented.
 
@@ -71,15 +70,7 @@ Machine"] for more information.
 [convene::web/readme.md "configuring your development machine"]:
   ./convene-web/README.md#configuring-your-development-machine
 
-### 2.2. Testing Setup and Documentation.
-
-We use Firefox web browser for interface testing.
-
-Make sure you have it installed and you can launch it from your terminal.
-
-If you use homebrew, install Firefox via: `brew install --cask firefox`
-
-### 2.3. Infrastructure Setup and Documentation.
+### 2.2. Infrastructure Setup and Documentation.
 
 Infrastructure engineers may want to look at the
 [`infrastructure` module's `README`](./infrastructure/README.md), which includes

--- a/bin/setup
+++ b/bin/setup
@@ -29,9 +29,13 @@ function setup_package {
   fi
 }
 
+## SYSTEM LEVEL DEPENDENCIES ##
 setup_package "overmind"
 setup_package "yarn"
 setup_package "shared-mime-info"
+# Firefox web browser is used for interface testing.
+brew install --cask firefox
+yarn global add maildev
 
 if test -f ".env"; then
   echo "Found .env, leaving it in place!"
@@ -40,9 +44,9 @@ else
   cp .env.example .env
 fi
 
+## APPLICATION LEVEL DEPENDENCIES ##
 # Installs environment dependencies such as packages and
 # prepares the application by running setup scripts in
 # each module
 yarn install
-yarn global add maildev
 (cd convene-web && bin/setup)


### PR DESCRIPTION
This ensures local dev environment has firefox needed to run bin/tests
script.

Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>